### PR TITLE
[7.x] Fix typo

### DIFF
--- a/x-pack/test/visual_regression/config.js
+++ b/x-pack/test/visual_regression/config.js
@@ -14,7 +14,7 @@ export default async function ({ readConfigFile }) {
 
     testFiles: [
       require.resolve('./tests/login_page'),
-      require.resolve('./tests/canvas')
+      require.resolve('./tests/canvas'),
       require.resolve('./tests/maps')
     ],
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Fix typo (fc9d141)