### PR TITLE
[7.4] Add more tests: discover, dashboard and maps

### DIFF
--- a/test/visual_regression/config.ts
+++ b/test/visual_regression/config.ts
@@ -29,6 +29,7 @@ export default async function({ readConfigFile }: FtrConfigProviderContext) {
     testFiles: [
       require.resolve('./tests/visualize/'),
       require.resolve('./tests/dashboard/'),
+      require.resolve('./tests/discover/'),
     ],
 
     services,

--- a/test/visual_regression/tests/dashboard/dashboard_filtering.js
+++ b/test/visual_regression/tests/dashboard/dashboard_filtering.js
@@ -35,7 +35,7 @@ export default function ({ getService, getPageObjects }) {
   const PageObjects = getPageObjects(['dashboard', 'header', 'visualize']);
   const visualTesting = getService('visualTesting');
 
-  describe.skip('dashboard filtering', function () {
+  describe('dashboard filtering', function () {
     this.tags('smoke');
     before(async () => {
       await PageObjects.dashboard.gotoDashboardLandingPage();

--- a/test/visual_regression/tests/discover/chart_visualization.js
+++ b/test/visual_regression/tests/discover/chart_visualization.js
@@ -1,0 +1,123 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import expect from '@kbn/expect';
+
+export default function ({ getService, getPageObjects }) {
+  const log = getService('log');
+  const retry = getService('retry');
+  const esArchiver = getService('esArchiver');
+  const browser = getService('browser');
+  const kibanaServer = getService('kibanaServer');
+  const PageObjects = getPageObjects(['common', 'discover', 'header', 'timePicker']);
+  const visualTesting = getService('visualTesting');
+  const defaultSettings = {
+    defaultIndex: 'logstash-*',
+  };
+
+  describe('discover', function describeIndexTests() {
+    const fromTime = '2015-09-19 06:31:44.000';
+    const toTime = '2015-09-23 18:31:44.000';
+
+    before(async function () {
+      log.debug('load kibana index with default index pattern');
+      await esArchiver.load('discover');
+
+      // and load a set of makelogs data
+      await esArchiver.loadIfNeeded('logstash_functional');
+      await kibanaServer.uiSettings.replace(defaultSettings);
+      log.debug('discover');
+      await PageObjects.common.navigateToApp('discover');
+      await PageObjects.timePicker.setAbsoluteRange(fromTime, toTime);
+    });
+
+    describe('query', function () {
+      this.tags(['skipFirefox']);
+
+      it('should show bars in the correct time zone', async function () {
+        await PageObjects.header.awaitGlobalLoadingIndicatorHidden();
+        await visualTesting.snapshot();
+      });
+
+      it('should show correct data for chart interval Hourly', async function () {
+        await PageObjects.header.awaitGlobalLoadingIndicatorHidden();
+        await PageObjects.discover.setChartInterval('Hourly');
+        await visualTesting.snapshot();
+      });
+
+      it('should show correct data for chart interval Daily', async function () {
+        await PageObjects.header.awaitGlobalLoadingIndicatorHidden();
+        await PageObjects.discover.setChartInterval('Daily');
+        await retry.try(async () => {
+          await visualTesting.snapshot();
+        });
+      });
+
+      it('should show correct data for chart interval Weekly', async function () {
+        await PageObjects.header.awaitGlobalLoadingIndicatorHidden();
+        await PageObjects.discover.setChartInterval('Weekly');
+        await retry.try(async () => {
+          await visualTesting.snapshot();
+        });
+      });
+
+      it('browser back button should show previous interval Daily', async function () {
+        await browser.goBack();
+        await retry.try(async function tryingForTime() {
+          const actualInterval = await PageObjects.discover.getChartInterval();
+          expect(actualInterval).to.be('Daily');
+        });
+        await PageObjects.header.awaitGlobalLoadingIndicatorHidden();
+        await visualTesting.snapshot();
+      });
+
+      it('should show correct data for chart interval Monthly', async function () {
+        await PageObjects.header.awaitGlobalLoadingIndicatorHidden();
+        await PageObjects.discover.setChartInterval('Monthly');
+        await visualTesting.snapshot();
+      });
+
+      it('should show correct data for chart interval Yearly', async function () {
+        await PageObjects.header.awaitGlobalLoadingIndicatorHidden();
+        await PageObjects.discover.setChartInterval('Yearly');
+        await visualTesting.snapshot();
+      });
+
+      it('should show correct data for chart interval Auto', async function () {
+        await PageObjects.header.awaitGlobalLoadingIndicatorHidden();
+        await PageObjects.discover.setChartInterval('Auto');
+        await visualTesting.snapshot();
+      });
+    });
+
+    describe('time zone switch', () => {
+      it('should show bars in the correct time zone after switching', async function () {
+        await kibanaServer.uiSettings.replace({ 'dateFormat:tz': 'America/Phoenix' });
+        await browser.refresh();
+        await PageObjects.header.awaitKibanaChrome();
+        await PageObjects.timePicker.setAbsoluteRange(fromTime, toTime);
+        await PageObjects.header.awaitGlobalLoadingIndicatorHidden();
+        await retry.try(async function () {
+          await visualTesting.snapshot();
+        });
+      });
+
+    });
+  });
+}

--- a/test/visual_regression/tests/discover/index.js
+++ b/test/visual_regression/tests/discover/index.js
@@ -1,0 +1,42 @@
+/*
+* Licensed to Elasticsearch B.V. under one or more contributor
+* license agreements. See the NOTICE file distributed with
+* this work for additional information regarding copyright
+* ownership. Elasticsearch B.V. licenses this file to you under
+* the Apache License, Version 2.0 (the "License"); you may
+* not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+import { DEFAULT_OPTIONS } from '../../services/visual_testing/visual_testing';
+
+// Width must be the same as visual_testing or canvas image widths will get skewed
+const [SCREEN_WIDTH] = DEFAULT_OPTIONS.widths || [];
+
+export default function ({ getService, loadTestFile }) {
+  const esArchiver = getService('esArchiver');
+  const browser = getService('browser');
+
+  describe('discover app', function () {
+    this.tags('ciGroup6');
+
+    before(function () {
+      return browser.setWindowSize(SCREEN_WIDTH, 1000);
+    });
+
+    after(function unloadMakelogs() {
+      return esArchiver.unload('logstash_functional');
+    });
+
+    loadTestFile(require.resolve('./chart_visualization'));
+  });
+}

--- a/x-pack/test/visual_regression/tests/canvas/smoke_test.js
+++ b/x-pack/test/visual_regression/tests/canvas/smoke_test.js
@@ -36,7 +36,8 @@ export default function canvasSmokeTest({ getService, getPageObjects }) {
         expect(workpadRows).to.have.length(1);
         expect(await workpadRows[0].getVisibleText()).to.equal('Test Workpad');
       });
-
+      
+      await PageObjects.common.sleep(5000);
       await visualTesting.snapshot();
 
     });
@@ -88,6 +89,7 @@ export default function canvasSmokeTest({ getService, getPageObjects }) {
         const timelionRows = await elements[3].findAllByCssSelector('.canvasDataTable tbody tr');
         expect(timelionRows).to.have.length(12);
 
+        await PageObjects.common.sleep(5000);
         await visualTesting.snapshot();
 
       });

--- a/x-pack/test/visual_regression/tests/maps/vector_styling.js
+++ b/x-pack/test/visual_regression/tests/maps/vector_styling.js
@@ -21,5 +21,33 @@ export default function ({ getPageObjects, getService }) {
       });
 
     });
+
+    describe('dynamic coloring', () => {
+      before(async () => {
+        await PageObjects.maps.loadSavedMap('join and dynamic coloring demo');
+        await PageObjects.maps.enterFullScreen();
+        await PageObjects.maps.closeLegend();
+      });
+
+      // eslint-disable-next-line max-len
+      it('should symbolize fill color with custom steps from join value and border color with dynamic color ramp from prop value', async () => {
+        await visualTesting.snapshot();
+      });
+
+    });
+
+    describe('dynamic line coloring', () => {
+      before(async () => {
+        await PageObjects.maps.loadSavedMap('pew pew demo');
+        await PageObjects.maps.enterFullScreen();
+        await PageObjects.maps.closeLegend();
+      });
+
+      // eslint-disable-next-line max-len
+      it('should symbolize pew pew lines', async () => {
+        await visualTesting.snapshot();
+      });
+
+    });
   });
 }


### PR DESCRIPTION
Backports the following commits to 7.4:
 - Add more tests: discover, dashboard and maps (#100)